### PR TITLE
Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/vazkii/arl/util/RegistryHelper.java
+++ b/src/main/java/vazkii/arl/util/RegistryHelper.java
@@ -145,21 +145,19 @@ public final class RegistryHelper {
 		BlockColors bcolors = mc.getBlockColors();
 		ItemColors icolors = mc.getItemColors();
 
-		while(!blockColors.isEmpty()) {
-			Pair<Block, IBlockColorProvider> pair = blockColors.poll();
+		blockColors.forEach(pair -> {
 			BlockColor color = pair.getSecond().getBlockColor();
 
 			if (color != null)
 				bcolors.register(color, pair.getFirst());
-		}
+		});
 
-		while(!itemColors.isEmpty()) {
-			Pair<Item, IItemColorProvider> pair = itemColors.poll();
+		itemColors.forEach(pair -> {
 			ItemColor color = pair.getSecond().getItemColor();
 
 			if (color != null)
 				icolors.register(color, pair.getFirst());
-		}
+		});
 
 		return true;
 	}


### PR DESCRIPTION
When calling poll() on a collection while looping over the collection,
can cause a race condition.

Fix by using foreach() on the collection.

Fixes https://github.com/VazkiiMods/AutoRegLib/issues/79